### PR TITLE
feat: execute Python code via pyodide

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,11 +6,12 @@
     "build": "tsc && vite build",
     "serve": "vite preview",
     "check:ts": "tsc --noEmit",
-    "lint": "eslint . --ext .tsx",
+    "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write src"
   },
   "dependencies": {
     "jotai": "^1.4.2",
+    "pyodide": "^0.18.2",
     "react": "^17.0.0",
     "react-ace": "^9.5.0",
     "react-dom": "^17.0.0"

--- a/ui/src/atoms/editor-atoms.ts
+++ b/ui/src/atoms/editor-atoms.ts
@@ -2,5 +2,5 @@ import { atom } from 'jotai';
 
 export const documentAtom = atom<string>('<h1>Hello cb-vis!</h1>');
 export const programAtom = atom<string>(
-  'def pows_of_2(n):\n\tfor i in range(n):\n\t\tprint(2 ** i)'
+  'def pows_of_2(n):\n\tfor i in range(n):\n\t\tprint(2 ** i)\n\npows_of_2(3)'
 );

--- a/ui/src/components/Editor.tsx
+++ b/ui/src/components/Editor.tsx
@@ -5,6 +5,7 @@ import 'ace-builds/src-noconflict/theme-dracula';
 
 import HtmlLogo from '../assets/html-logo.svg';
 import PythonLogo from '../assets/python-logo.svg';
+import { EditorError } from '../types/editor';
 
 import styles from './Editor.module.css';
 
@@ -12,9 +13,10 @@ interface Props {
   source: string;
   setSource: (value: string) => void;
   mode: 'python' | 'html';
+  error?: EditorError;
 }
 
-const Editor: React.FC<Props> = ({ source, setSource, mode }) => {
+const Editor: React.FC<Props> = ({ source, setSource, mode, error }) => {
   const { src, alt } =
     mode === 'html'
       ? { src: HtmlLogo, alt: 'HTML' }
@@ -31,6 +33,16 @@ const Editor: React.FC<Props> = ({ source, setSource, mode }) => {
         height="100%"
         width="100%"
         fontSize={14}
+        annotations={
+          error && [
+            {
+              row: error.lineNumber - 1,
+              column: 0,
+              text: 'Syntax error',
+              type: 'error',
+            },
+          ]
+        }
       />
       <img src={src} alt={alt} className={styles['lang-logo']} />
     </>

--- a/ui/src/helpers/traceback.ts
+++ b/ui/src/helpers/traceback.ts
@@ -1,0 +1,7 @@
+export const getExceptionLineNumber = (tb: string): number => {
+  const lineIdx = tb.lastIndexOf('line ') + 'line '.length;
+  const searchString = tb.slice(lineIdx);
+  const lineno = searchString.slice(0, searchString.indexOf('\n'));
+
+  return parseInt(lineno, 10);
+};

--- a/ui/src/types/editor.ts
+++ b/ui/src/types/editor.ts
@@ -1,0 +1,3 @@
+export interface EditorError {
+  lineNumber: number;
+}

--- a/ui/src/types/pyodide.ts
+++ b/ui/src/types/pyodide.ts
@@ -1,0 +1,6 @@
+export interface Pyodide {
+  runPython: (source: string) => void;
+  PythonError: {
+    name: string;
+  };
+}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -530,6 +530,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-64@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
+  integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1558,6 +1563,13 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+node-fetch@^2.6.1:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
@@ -1747,6 +1759,14 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pyodide@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/pyodide/-/pyodide-0.18.2.tgz#6c2dbfcac3f0a5f6e2bd5d2d2766aea50e4c29f0"
+  integrity sha512-t4Mi75oDHc3NPmF8CjpiQ6/oMrxzT7ktv0WAyCnM4PcVG4uQ5bce3jZpeOQhrbUWUYhx3clwhsSGj9JawMm3Ug==
+  dependencies:
+    base-64 "^1.0.0"
+    node-fetch "^2.6.1"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -1995,6 +2015,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tsconfig-paths@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
@@ -2067,6 +2092,19 @@ vite@^2.6.4:
     rollup "^2.57.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR wires up [pyodide](https://pyodide.org/en/stable/) to our UI to execute Python code.

<img src="https://user-images.githubusercontent.com/19421190/140793550-2098be7c-d6f6-4b30-9475-b971202893ac.gif" alt="cb-vis Python execution" width="600" height="360" />

The key features are:

- Safely load and initialize pyodide, which has some trickiness to handle due to its multipart module setup (the `npm` module loads the loader, the `loadPyodide` function loads the actual WASM module).
- Execute source from our Python editor.
- Catch errors in the Python program with line highlighting to indicate the offending line. We could get even more granular with our error reporting, but it would be a time investment that doesn't totally feel worthwhile right now since it's not the main event.

The next step will be to get this Python code executing in the context of the HTML editor (`iframe`) rather than in the top-level `window`.