### PR TITLE
feat: execute Python code in response to UI control

### DIFF
--- a/ui/src/App.module.css
+++ b/ui/src/App.module.css
@@ -1,8 +1,6 @@
 .panel {
-  grid-column: span 1;
-  grid-row: span 1;
-  border: 1px solid #ffffff;
   display: flex;
   flex-direction: column;
   position: relative;
+  border: 1px solid var(--text-primary);
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -32,22 +32,28 @@ const App: React.FC = () => {
       };
 
       initPyodide();
-    } else {
-      try {
-        pyodide.current?.runPython(pythonSource);
+    }
+  }, [pyodideInitialized]);
+
+  const executePython = React.useCallback(() => {
+    try {
+      pyodide.current?.runPython(pythonSource);
+
+      // If we have an existing error flagged from a previous execution, remove it.
+      if (pythonError) {
         setPythonError(undefined);
-      } catch (err) {
-        if (
-          err instanceof Error &&
-          err.name === pyodide.current?.PythonError.name
-        ) {
-          setPythonError({
-            lineNumber: getExceptionLineNumber(err.message),
-          });
-        }
+      }
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.name === pyodide.current?.PythonError.name
+      ) {
+        setPythonError({
+          lineNumber: getExceptionLineNumber(err.message),
+        });
       }
     }
-  }, [pyodideInitialized, pythonSource]);
+  }, [pythonSource, pythonError]);
 
   return (
     <>
@@ -64,7 +70,7 @@ const App: React.FC = () => {
           mode="python"
           error={pythonError}
         />
-        <DebuggerControls />
+        <DebuggerControls onExecute={executePython} />
       </div>
       <div className={styles.panel}></div>
     </>

--- a/ui/src/components/DebuggerControls.module.css
+++ b/ui/src/components/DebuggerControls.module.css
@@ -1,4 +1,26 @@
 .debugger-controls {
   height: 40px;
-  border: 2px solid steelblue;
+  background: var(--editor-primary);
+  border-top: 1px solid var(--text-primary);
+  display: flex;
+  align-items: center;
+}
+
+.debugger-controls__button {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 var(--spacing-md);
+  background: none;
+  border: none;
+  color: var(--text-primary);
+}
+
+.debugger-controls__button:hover {
+  background: var(--editor-secondary);
+}
+
+.debugger-controls__icon {
+  padding-right: var(--spacing-sm);
+  cursor: pointer;
 }

--- a/ui/src/components/DebuggerControls.tsx
+++ b/ui/src/components/DebuggerControls.tsx
@@ -1,7 +1,56 @@
 import styles from './DebuggerControls.module.css';
 
-const DebuggerControls: React.FC = () => (
-  <div className={styles['debugger-controls']}>Debugger Controls</div>
+interface Props {
+  onExecute: () => void;
+}
+
+const DebuggerControls: React.FC<Props> = ({ onExecute }) => (
+  <div className={styles['debugger-controls']}>
+    <button
+      onClick={onExecute}
+      className={styles['debugger-controls__button']}
+      type="button"
+      name="execute"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        className={styles['debugger-controls__icon']}
+      >
+        <path d="m5 3 14 9-14 9V3z" />
+      </svg>
+      Execute
+    </button>
+    <button
+      onClick={(): void => console.log('Play script to end!')}
+      className={styles['debugger-controls__button']}
+      type="button"
+      name="play-to-end"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        className={styles['debugger-controls__icon']}
+      >
+        <path d="m13 19 9-7-9-7v14zM2 19l9-7-9-7v14z" />
+      </svg>
+      Play to End
+    </button>
+  </div>
 );
 
 export default DebuggerControls;

--- a/ui/src/components/Editor.module.css
+++ b/ui/src/components/Editor.module.css
@@ -1,6 +1,6 @@
 .lang-logo {
-  height: 30px;
+  height: 3rem;
   position: absolute;
-  top: 5px;
-  right: 5px;
+  top: var(--spacing-sm);
+  right: var(--spacing-sm);
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,3 +1,15 @@
+:root {
+  --editor-primary: #282a35;
+  --editor-secondary: #444759;
+  --text-primary: #ffffff;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+}
+
+html {
+  font-size: 10px;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
This PR makes one small change — ensuring our Python code executes in response to a user interaction (clicking the "Execute" button) rather than on application load. Additionally, I've started filling in the Debugger Controls portion of the UI.

<img width="1515" alt="image" src="https://user-images.githubusercontent.com/19421190/141516138-e82cd34f-2ee3-40d2-b130-a378021009af.png">

The actual changes in this PR are small, but they set up a single entry point for us to start defining the behavior of these different UI controls. @SybelBlue I can't recall what our third debugger control was going to be 🤔 The two I have in there are:

- Execute — this will start stepping through the code line by line.
- Play to End — this will "flush" all remaining parts of the traceback and complete execution of the Python code.

These names are totally arbitrary and I'd love your input on changing them to be more meaningful!

I also did a bit of cleanup to start using CSS Variables and `rem` units so our styling doesn't get messy (I was wild westing it for a bit but felt like it was time to get at least some minimal structure in place).