### PR TITLE
feat: blur iframe while stepping

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@xstate/react": "^1.6.2",
+    "classnames": "^2.3.1",
     "jotai": "^1.4.2",
     "pyodide": "^0.18.2",
     "react": "^17.0.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -139,7 +139,7 @@ const App: React.FC = () => {
         />
       </div>
       <div className={styles.panel}>
-        <Document srcDoc={htmlSource} />
+        <Document srcDoc={htmlSource} blurred={current.value === 'idle'} />
       </div>
       <div className={styles.panel}>
         <Editor

--- a/ui/src/components/Console.tsx
+++ b/ui/src/components/Console.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cs from 'classnames';
 
 import TerminalIcon from '../assets/terminal.svg';
 
@@ -46,7 +47,10 @@ const Console: React.FC<Props> = ({ stdout, stderr }) => {
         ? stdErrStatements.map((statement, i) => (
             <p
               key={`${statement}-${i}`}
-              className={`${styles['console__stmt']} ${styles['console__stmt--stderr']}`}
+              className={cs(
+                styles['console__stmt'],
+                styles['console__stmt--stderr']
+              )}
             >
               {InputIcon}
               {statement}

--- a/ui/src/components/Document.module.css
+++ b/ui/src/components/Document.module.css
@@ -6,3 +6,10 @@
 .document--blurred {
   filter: blur(5px);
 }
+
+.document__overlay {
+  position: absolute;
+  z-index: 1;
+  height: 100%;
+  width: 100%;
+}

--- a/ui/src/components/Document.module.css
+++ b/ui/src/components/Document.module.css
@@ -2,3 +2,7 @@
   height: 100%;
   border: 0;
 }
+
+.document--blurred {
+  filter: blur(5px);
+}

--- a/ui/src/components/Document.tsx
+++ b/ui/src/components/Document.tsx
@@ -1,12 +1,19 @@
+import cs from 'classnames';
+
 import styles from './Document.module.css';
 
 interface Props {
   srcDoc: string;
+  blurred: boolean;
 }
 
-const Document: React.FC<Props> = ({ srcDoc }) => {
+const Document: React.FC<Props> = ({ srcDoc, blurred }) => {
   return (
-    <iframe className={styles.document} title="document" srcDoc={srcDoc} />
+    <iframe
+      className={cs(styles['document'], blurred && styles['document--blurred'])}
+      title="document"
+      srcDoc={srcDoc}
+    />
   );
 };
 

--- a/ui/src/components/Document.tsx
+++ b/ui/src/components/Document.tsx
@@ -9,11 +9,17 @@ interface Props {
 
 const Document: React.FC<Props> = ({ srcDoc, blurred }) => {
   return (
-    <iframe
-      className={cs(styles['document'], blurred && styles['document--blurred'])}
-      title="document"
-      srcDoc={srcDoc}
-    />
+    <>
+      <iframe
+        className={cs(
+          styles['document'],
+          blurred && styles['document--blurred']
+        )}
+        title="document"
+        srcDoc={srcDoc}
+      />
+      {blurred ? <div className={styles['document__overlay']} /> : null}
+    </>
   );
 };
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -604,6 +604,11 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"


### PR DESCRIPTION
This PR ensures that the rendered `iframe` is blurred and non-interactable while stepping through the Python source. Here's what a user will see while stepping through the code.

<img width="1477" alt="image" src="https://user-images.githubusercontent.com/19421190/143131281-cb87acaa-ea0a-425f-9045-cbe33c914676.png">

We can dial up the blur easily right in the CSS if we like; I chose a relatively low blur so that DOM elements are still somewhat recognizable. We also conditionally render an overlay above the `iframe` to ensure that elements are not easily interactable while stepping.